### PR TITLE
Fix intersection kind decoding

### DIFF
--- a/flow_py_sdk/cadence/kinds.py
+++ b/flow_py_sdk/cadence/kinds.py
@@ -440,7 +440,7 @@ class IntersectionKind(Kind):
 
     @classmethod
     def kind_str(cls) -> str:
-        return "Restriction"
+        return "Intersection"
 
 
 class CapabilityKind(Kind):

--- a/tests/cadence/encode_test.py
+++ b/tests/cadence/encode_test.py
@@ -1281,9 +1281,9 @@ class TestEncode(unittest.TestCase):
         )
         self._encodeAndDecodeAll([kind])
 
-    def testRestrictedKind(self):
+    def testIntersectionKind(self):
         kind = _EncodeTestParams(
-            "Restricted Kind",
+            "Intersection Kind",
             cadence.IntersectionKind(
                 "0x3.GreatContract.GreatNFT",
                 [
@@ -1301,7 +1301,7 @@ class TestEncode(unittest.TestCase):
             ),
             """
             {
-              "kind": "Restriction",
+              "kind": "Intersection",
               "typeID": "0x3.GreatContract.GreatNFT",
               "types": [
                 {


### PR DESCRIPTION
With cadence 1.0 **Restriction** became **Intersection**

This change in decoding was missing.